### PR TITLE
Support for Sidekiq 2.3 or higher.

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 2.0.0-p247@sidekiq_status --create

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ env:
     - SIDEKIQ_VERSION="~>2.14.0"
     - SIDEKIQ_VERSION="~>2.15.0"
     - SIDEKIQ_VERSION="~>2.16.0"
+    - SIDEKIQ_VERSION="~>2.17.0"
 script: bundle exec rake

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -259,11 +259,13 @@ module SidekiqStatus
 
     # @return [Integer] Job progress in percents (reported solely by {SidekiqStatus::Worker job})
     def pct_complete
-      (at.to_f / total.to_f * 100).round
-    rescue ZeroDivisionError
-      0
-    rescue FloatDomainError
-      0
+      begin
+        (at.to_f / total.to_f * 100).round
+      rescue ZeroDivisionError
+        0
+      rescue FloatDomainError
+        0
+      end
     end
 
     # @param [Fixnum] at Report the progress of a job which is tracked by the current {SidekiqStatus::Container}

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -259,7 +259,7 @@ module SidekiqStatus
 
     # @return [Integer] Job progress in percents (reported solely by {SidekiqStatus::Worker job})
     def pct_complete
-      (at.to_f / total * 100).round
+      (at.to_f / total.to_f * 100).round
     end
 
     # @param [Fixnum] at Report the progress of a job which is tracked by the current {SidekiqStatus::Container}

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -260,6 +260,8 @@ module SidekiqStatus
     # @return [Integer] Job progress in percents (reported solely by {SidekiqStatus::Worker job})
     def pct_complete
       (at.to_f / total.to_f * 100).round
+    rescue ZeroDivisionError
+      0
     end
 
     # @param [Fixnum] at Report the progress of a job which is tracked by the current {SidekiqStatus::Container}

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -262,6 +262,8 @@ module SidekiqStatus
       (at.to_f / total.to_f * 100).round
     rescue ZeroDivisionError
       0
+    rescue FloatDomainError
+      0
     end
 
     # @param [Fixnum] at Report the progress of a job which is tracked by the current {SidekiqStatus::Container}

--- a/sidekiq_status.gemspec
+++ b/sidekiq_status.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SidekiqStatus::VERSION
 
-  gem.add_runtime_dependency("sidekiq", ">= 2.4", "< 2.17")
+  gem.add_runtime_dependency("sidekiq", "~> 2.4")
 
   gem.add_development_dependency("activesupport")
   gem.add_development_dependency("rspec")


### PR DESCRIPTION
This passes all specs and has been tested in production. I recommend not capping the maximum version of Sidekiq until an incompatibility is identified.
